### PR TITLE
Changed the default of account name for display to online identity if existing

### DIFF
--- a/lib/utils/index.dart
+++ b/lib/utils/index.dart
@@ -32,7 +32,7 @@ class UI {
   }
 
   static String accountName(BuildContext context, KeyPairData acc) {
-    return '${accountDisplayNameString(acc.address, acc.name.isEmpty ? acc.indexInfo : null, acc.name)}' +
+    return '${accountDisplayNameString(acc.address, acc.indexInfo, acc.name)}' +
         '${(acc.observation ?? false) ? ' (${I18n.of(context).getDic(i18n_full_dic_ui, 'account')['observe']})' : ''}';
   }
 

--- a/lib/utils/index.dart
+++ b/lib/utils/index.dart
@@ -32,7 +32,8 @@ class UI {
   }
 
   static String accountName(BuildContext context, KeyPairData acc) {
-    return '${acc.name ?? accountDisplayNameString(acc.address, acc.indexInfo)}${(acc.observation ?? false) ? ' (${I18n.of(context).getDic(i18n_full_dic_ui, 'account')['observe']})' : ''}';
+    return '${accountDisplayNameString(acc.address, acc.name.isEmpty ? acc.indexInfo : null, acc.name)}' +
+        '${(acc.observation ?? false) ? ' (${I18n.of(context).getDic(i18n_full_dic_ui, 'account')['observe']})' : ''}';
   }
 
   static Widget accountDisplayName(
@@ -84,8 +85,9 @@ class UI {
     );
   }
 
-  static String accountDisplayNameString(String address, Map accInfo) {
-    String display = Fmt.address(address, pad: 6);
+  static String accountDisplayNameString(String address, Map accInfo,
+      [String localName = ""]) {
+    String display = localName ?? Fmt.address(address, pad: 6);
     if (accInfo != null) {
       if (accInfo['identity']['display'] != null) {
         display = accInfo['identity']['display'];


### PR DESCRIPTION
The current behaviour is to always use the local naming, and only if missing to  pull out information from the chain first using onchain IDs or last formatting the address. However, in case an account has an onchain ID, one may want to get it displayed instead of local naming. The new behaviour is also consistent with the Polkadot.js apps and extension.

There is incidentally a problem in the SDK that needs to be fixed to populate the right information in the KeyPairData. This is the subject of [another pull request in SDK](https://github.com/polkawallet-io/sdk/pull/7).

_Note that I initially wanted to introduce a switch in the settings, but I did not find any elegant way to retrieve the value from the app storage within the plugins. I can rework all this if you believe a switch would be useful and have a suggestion on how to carry on the global state of the boolean variable representing the switch to all the calls to accountName._


